### PR TITLE
Increase backend resource allocations

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: developer-portal-backend
 description: A Helm chart for deploying the Diamond developer portal backend
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.0.26
 dependencies:
   - name: common

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -13,7 +13,7 @@ resources:
     cpu: 100m
     memory: 1Gi
   limits:
-    cpu: 200m
+    cpu: 1000m
     memory: 2Gi
 
 postgres:


### PR DESCRIPTION
Recently the backend pod has been throttling at 200m CPU periodically every 10 minutes. This change attempts to stop the throttling and the alerts that are sent each time it happens.