### PR TITLE
Move backend secret checksum to annotation

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: developer-portal-backend
 description: A Helm chart for deploying the Diamond developer portal backend
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.0.26
 dependencies:
   - name: common

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -12,9 +12,10 @@ spec:
       {{- include "common.labels.matchLabels" $ | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
         {{- include "common.labels.standard" $ | nindent 8 }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "common.names.fullname" $ }}


### PR DESCRIPTION
The SHA256 sum was too large for a label, this moves it to an annotation as suggested [in the docs](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)