### PR TITLE
Ignore differences in password secret when deploying postgres argocd app

### DIFF
--- a/charts/apps/Chart.yaml
+++ b/charts/apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: developer-portal
 description: An ArgoCD App of Apps for deploying the Developer Portal
 type: application
-version: 0.1.0
+version: 0.1.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/charts/apps/templates/postgres-app.yaml
+++ b/charts/apps/templates/postgres-app.yaml
@@ -30,6 +30,13 @@ spec:
     name: {{ .Values.destination.name }}
     server: {{ .Values.destination.server }}
     namespace: {{ default .Release.Namespace .Values.destination.namespace }}
+  ignoreDifferences:
+    - kind: Secret
+      name: {{ include "common.names.fullname" $ }}-postgresq
+      namespace: {{ default .Release.Namespace .Values.destination.namespace }}
+      jqPathExpressions:
+        - .data.password
+        - .data."postgres-password"
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Erroneous updates to this `Secret` were causing the password in the backend deployment to differ from that held by the postgres instance - unfortunately as ArgoCD performs a `helm template` followed by a `kubectl apply` the helm chart templates do not adequately avoid these updates