### PR TITLE
Remove broken health checks

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: developer-portal-backend
 description: A Helm chart for deploying the Diamond developer portal backend
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.0.26
 dependencies:
   - name: common

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -83,15 +83,3 @@ spec:
           ports:
             - name: http-api
               containerPort: 7007
-          livenessProbe:
-            httpGet:
-              port: 7007
-              path: /healthcheck
-            initialDelaySeconds: 30
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              port: 7007
-              path: /healthcheck
-            initialDelaySeconds: 30
-            periodSeconds: 10


### PR DESCRIPTION
This version of backstage does not have these endpoints, so the readiness checks never succeed.